### PR TITLE
Add Indian Rupee formatting with shorthand notation

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -18,6 +18,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { Badge } from '@/components/ui/badge'
 import { Bill, BillInstance, BillType, BillFrequency } from '@/types'
+import { formatPrice } from '@/lib/formatPrice'
 
 type TabValue = 'INCOME' | 'BILLS' | 'INSTANCES'
 
@@ -348,7 +349,7 @@ function BillsTable({ bills }: { bills: Bill[] }) {
                       : null}
                     {bill.frequency === 'YEARLY' && bill.start_date ? formatDate(bill.start_date) : null}
                   </TableCell>
-                  <TableCell>{bill.amount !== null && bill.amount !== undefined ? bill.amount.toFixed(2) : 'Variable'}</TableCell>
+                  <TableCell>{bill.amount !== null && bill.amount !== undefined ? formatPrice(bill.amount) : 'Variable'}</TableCell>
                   <TableCell>
                     {bill.auto_post ? <Badge variant="secondary">Auto</Badge> : <Badge variant="outline">Manual</Badge>}
                   </TableCell>

--- a/components/common/AnalyticsPreviewCard.tsx
+++ b/components/common/AnalyticsPreviewCard.tsx
@@ -10,6 +10,7 @@ import { supabase } from '@/server/db/supabase'
 import { Expense } from '@/types'
 import { getSummaryTotals, getCategoryTotals } from '@/lib/analytics'
 import { fromUTC } from '@/lib/datetime'
+import { formatPrice } from '@/lib/formatPrice'
 
 export function AnalyticsPreviewCard() {
   const [expenses, setExpenses] = useState<Expense[]>([])
@@ -87,15 +88,15 @@ export function AnalyticsPreviewCard() {
       <CardHeader className="pb-2">
         <CardTitle className="text-lg">Analytics</CardTitle>
         <CardDescription>
-          {expenses.length} transaction{expenses.length !== 1 ? 's' : ''} • {summary.net >= 0 ? (
+          {expenses.length} transaction{expenses.length !== 1 ? 's' : ''} •           {summary.net >= 0 ? (
             <span className="text-green-600 flex items-center gap-1">
               <TrendingUp className="h-3 w-3" />
-              +₹{summary.net.toLocaleString()}
+              +{formatPrice(summary.net)}
             </span>
           ) : (
             <span className="text-red-600 flex items-center gap-1">
               <TrendingDown className="h-3 w-3" />
-              -₹{Math.abs(summary.net).toLocaleString()}
+              -{formatPrice(Math.abs(summary.net))}
             </span>
           )}
         </CardDescription>
@@ -106,11 +107,11 @@ export function AnalyticsPreviewCard() {
           <div className="grid grid-cols-2 gap-4 text-sm">
             <div>
               <p className="text-muted-foreground">Expenses</p>
-              <p className="font-medium text-red-600">₹{summary.expenseTotal.toLocaleString()}</p>
+              <p className="font-medium text-red-600">{formatPrice(summary.expenseTotal)}</p>
             </div>
             <div>
               <p className="text-muted-foreground">Income</p>
-              <p className="font-medium text-green-600">₹{summary.inflowTotal.toLocaleString()}</p>
+              <p className="font-medium text-green-600">{formatPrice(summary.inflowTotal)}</p>
             </div>
           </div>
 
@@ -124,7 +125,7 @@ export function AnalyticsPreviewCard() {
                       {category.name}
                     </span>
                     <Badge variant="secondary" className="text-xs">
-                      ₹{category.value.toLocaleString()}
+                      {formatPrice(category.value)}
                     </Badge>
                   </div>
                 ))}

--- a/components/common/BillsPreviewCard.tsx
+++ b/components/common/BillsPreviewCard.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import { supabase } from '@/server/db/supabase'
 import { BillInstance } from '@/types'
+import { formatPrice } from '@/lib/formatPrice'
 
 export function BillsPreviewCard() {
   const [billInstances, setBillInstances] = useState<BillInstance[]>([])
@@ -79,7 +80,7 @@ export function BillsPreviewCard() {
       <CardHeader className="pb-2">
         <CardTitle className="text-lg">Upcoming Bills</CardTitle>
         <CardDescription>
-          {billInstances.length} bill{billInstances.length !== 1 ? 's' : ''} • ₹{totalAmount.toLocaleString()}
+          {billInstances.length} bill{billInstances.length !== 1 ? 's' : ''} • {formatPrice(totalAmount)}
         </CardDescription>
       </CardHeader>
 
@@ -98,7 +99,7 @@ export function BillsPreviewCard() {
                     {dayjs(instance.due_date).format('MMM D')}
                   </Badge>
                 </div>
-                <span className="font-medium">₹{instance.amount.toLocaleString()}</span>
+                <span className="font-medium">{formatPrice(instance.amount)}</span>
               </div>
             ))}
           </div>

--- a/components/common/DataTable.tsx
+++ b/components/common/DataTable.tsx
@@ -14,6 +14,7 @@ import {
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Expense } from "@/types"
+import { formatPrice } from "@/lib/formatPrice"
 
 interface DataTableProps {
   expenses: Expense[]
@@ -96,7 +97,7 @@ export function DataTable({ expenses, isLoading, currency }: DataTableProps) {
                         )}
                       </span>
                       <span className="font-medium">
-                        {expense.currency} {expense.amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                        {formatPrice(expense.amount)}
                       </span>
                     </div>
                   </TableCell>

--- a/components/common/ExpensesPreviewCard.tsx
+++ b/components/common/ExpensesPreviewCard.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { supabase } from '@/server/db/supabase'
 import { Expense } from '@/types'
 import { fromUTC } from '@/lib/datetime'
+import { formatPrice } from '@/lib/formatPrice'
 
 export function ExpensesPreviewCard() {
   const [expenses, setExpenses] = useState<Expense[]>([])
@@ -82,7 +83,7 @@ export function ExpensesPreviewCard() {
       <CardHeader className="pb-2">
         <CardTitle className="text-lg">Recent Expenses</CardTitle>
         <CardDescription>
-          {expenses.length} transaction{expenses.length !== 1 ? 's' : ''} • ₹{totalAmount.toLocaleString()}
+          {expenses.length} transaction{expenses.length !== 1 ? 's' : ''} • {formatPrice(totalAmount)}
         </CardDescription>
       </CardHeader>
 
@@ -101,7 +102,7 @@ export function ExpensesPreviewCard() {
                     {expense.type}
                   </Badge>
                 </div>
-                <span className="font-medium">₹{expense.amount.toLocaleString()}</span>
+                <span className="font-medium">{formatPrice(expense.amount)}</span>
               </div>
             ))}
           </div>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import dayjs from 'dayjs'
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card'
 import { Button } from '../ui/button'
 import { View } from '@/types'
+import { formatPrice } from '@/lib/formatPrice'
 
 interface HeaderProps {
   monthlyTotal: number
@@ -26,7 +27,7 @@ export function Header({ monthlyTotal, currency, view, onViewChange }: HeaderPro
           <div>
             <p className="text-sm text-muted-foreground">Monthly Total ({currentMonth})</p>
             <p className={`text-3xl font-bold ${monthlyTotal < 0 ? 'text-red-600' : 'text-green-600'}`}>
-              {monthlyTotal < 0 ? '-' : ''}{currency} {Math.abs(monthlyTotal).toLocaleString()}
+              {monthlyTotal < 0 ? '-' : ''}{formatPrice(Math.abs(monthlyTotal))}
             </p>
           </div>
           <div className="text-right">

--- a/features/analytics/components/AnalyticsDashboard.tsx
+++ b/features/analytics/components/AnalyticsDashboard.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { TrendPeriod, getCategoryTotals, getCategoryTrend, getAvailableCategories, getPaymentMethodStats, getPlatformStats, getFilteredSpendingTrend, getSummaryTotals } from '@lib/analytics'
 import { Expense } from '@/types'
 import { Button } from '@components/ui/button'
+import { formatPrice } from '@/lib/formatPrice'
 import { AnimatedButton } from '@lib/animations'
 import { Card, CardContent, CardHeader, CardTitle } from '@components/ui/card'
 import { CategoryPieChart } from '@features/analytics/components/CategoryPieChart'
@@ -222,7 +223,7 @@ type SummaryStatProps = {
 
 function SummaryStat({ label, value, currency, tone }: SummaryStatProps) {
   const isExpense = tone === 'EXPENSE'
-  const formatted = `${currency} ${Math.abs(value).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+  const formatted = formatPrice(Math.abs(value))
 
   return (
     <div className="rounded-lg border bg-muted/40 p-4">
@@ -259,8 +260,7 @@ function HighlightsList({ title, items, currency, emptyLabel }: HighlightsListPr
             <li key={item.name} className="flex items-center justify-between rounded-md bg-background p-2">
               <span className="font-medium">{item.name}</span>
               <span>
-                {currency}{' '}
-                {item.amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                {formatPrice(item.amount)}
               </span>
             </li>
           ))}

--- a/features/analytics/components/CategoryPieChart.tsx
+++ b/features/analytics/components/CategoryPieChart.tsx
@@ -4,7 +4,8 @@ import * as React from 'react'
 import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts'
 
 import { SimpleDatum } from '@lib/analytics'
-import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from '@components/ui/chart'
+import { ChartConfig, ChartContainer, ChartTooltip } from '@components/ui/chart'
+import { formatPrice } from '@/lib/formatPrice'
 
 type CategoryPieChartProps = {
   data: SimpleDatum[]
@@ -36,6 +37,27 @@ export function CategoryPieChart({ data }: CategoryPieChartProps) {
     return data.map((_, index) => `hsl(var(--chart-${(index % 5) + 1}))`)
   }, [data])
 
+  const CustomTooltip = ({ active, payload }: any) => {
+    if (active && payload && payload.length) {
+      const data = payload[0].payload
+      return (
+        <div className="rounded-lg border bg-background p-2 shadow-sm">
+          <div className="grid grid-cols-1 gap-2">
+            <div className="flex flex-col">
+              <span className="text-[0.70rem] uppercase text-muted-foreground">
+                {data.name}
+              </span>
+              <span className="font-bold">
+                {formatPrice(data.value)}
+              </span>
+            </div>
+          </div>
+        </div>
+      )
+    }
+    return null
+  }
+
   if (!mounted) {
     return (
       <div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
@@ -66,7 +88,7 @@ export function CategoryPieChart({ data }: CategoryPieChartProps) {
             <Cell key={`cell-${entry.name}`} fill={COLORS[index]} />
           ))}
         </Pie>
-        <ChartTooltip content={<ChartTooltipContent hideLabel />} />
+        <ChartTooltip content={<CustomTooltip />} />
         <Legend />
       </PieChart>
     </ChartContainer>

--- a/features/analytics/components/CategoryTrendsChart.tsx
+++ b/features/analytics/components/CategoryTrendsChart.tsx
@@ -10,7 +10,8 @@ import {
 } from 'recharts'
 
 import { CategoryTrendPoint } from '@lib/analytics'
-import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent, ChartLegend, ChartLegendContent } from '@components/ui/chart'
+import { ChartConfig, ChartContainer, ChartTooltip, ChartLegend, ChartLegendContent } from '@components/ui/chart'
+import { formatPrice } from '@/lib/formatPrice'
 
 type CategoryTrendsChartProps = {
   data: CategoryTrendPoint[]
@@ -38,6 +39,28 @@ export function CategoryTrendsChart({ data, categories }: CategoryTrendsChartPro
   const COLORS = React.useMemo(() => {
     return categories.map((_, index) => `hsl(var(--chart-${(index % 5) + 1}))`)
   }, [categories])
+
+  const CustomTooltip = ({ active, payload, label }: any) => {
+    if (active && payload && payload.length) {
+      return (
+        <div className="rounded-lg border bg-background p-2 shadow-sm">
+          <div className="grid grid-cols-1 gap-2">
+            <div className="flex flex-col">
+              <span className="text-[0.70rem] uppercase text-muted-foreground">
+                {label}
+              </span>
+              {payload.map((entry: any, index: number) => (
+                <span key={index} className="font-bold" style={{ color: entry.color }}>
+                  {entry.name}: {formatPrice(entry.value)}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      )
+    }
+    return null
+  }
 
   if (!mounted) {
     return (
@@ -82,7 +105,7 @@ export function CategoryTrendsChart({ data, categories }: CategoryTrendsChartPro
           tickMargin={8}
           width={60}
         />
-        <ChartTooltip content={<ChartTooltipContent />} />
+        <ChartTooltip content={<CustomTooltip />} />
         <ChartLegend content={<ChartLegendContent />} />
         {categories.map((category, index) => (
           <Area

--- a/features/analytics/components/PaymentMethodChart.tsx
+++ b/features/analytics/components/PaymentMethodChart.tsx
@@ -4,7 +4,8 @@ import * as React from 'react'
 import { Bar, BarChart, XAxis, YAxis } from 'recharts'
 
 import { ComparisonDatum } from '@lib/analytics'
-import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from '@components/ui/chart'
+import { ChartConfig, ChartContainer, ChartTooltip } from '@components/ui/chart'
+import { formatPrice } from '@/lib/formatPrice'
 
 type PaymentMethodChartProps = {
   data: ComparisonDatum[]
@@ -16,6 +17,26 @@ const chartConfig = {
     color: "hsl(var(--chart-2))",
   },
 } satisfies ChartConfig
+
+const CustomTooltip = ({ active, payload, label }: any) => {
+  if (active && payload && payload.length) {
+    return (
+      <div className="rounded-lg border bg-background p-2 shadow-sm">
+        <div className="grid grid-cols-1 gap-2">
+          <div className="flex flex-col">
+            <span className="text-[0.70rem] uppercase text-muted-foreground">
+              {label}
+            </span>
+            <span className="font-bold">
+              Expenses: {formatPrice(payload[0].value)}
+            </span>
+          </div>
+        </div>
+      </div>
+    )
+  }
+  return null
+}
 
 export function PaymentMethodChart({ data }: PaymentMethodChartProps) {
   const [mounted, setMounted] = React.useState(false)
@@ -53,7 +74,7 @@ export function PaymentMethodChart({ data }: PaymentMethodChartProps) {
           tickLine={false}
           axisLine={false}
         />
-        <ChartTooltip content={<ChartTooltipContent />} />
+        <ChartTooltip content={<CustomTooltip />} />
         <Bar 
           dataKey="expense" 
           name="Expenses" 

--- a/features/analytics/components/PlatformBarChart.tsx
+++ b/features/analytics/components/PlatformBarChart.tsx
@@ -4,7 +4,8 @@ import * as React from 'react'
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts'
 
 import { ComparisonDatum } from '@lib/analytics'
-import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from '@components/ui/chart'
+import { ChartConfig, ChartContainer, ChartTooltip } from '@components/ui/chart'
+import { formatPrice } from '@/lib/formatPrice'
 
 type PlatformBarChartProps = {
   data: ComparisonDatum[]
@@ -17,6 +18,26 @@ const chartConfig = {
     color: "hsl(var(--chart-1))",
   },
 } satisfies ChartConfig
+
+const CustomTooltip = ({ active, payload, label }: any) => {
+  if (active && payload && payload.length) {
+    return (
+      <div className="rounded-lg border bg-background p-2 shadow-sm">
+        <div className="grid grid-cols-1 gap-2">
+          <div className="flex flex-col">
+            <span className="text-[0.70rem] uppercase text-muted-foreground">
+              {label}
+            </span>
+            <span className="font-bold">
+              {payload[0].name}: {formatPrice(payload[0].value)}
+            </span>
+          </div>
+        </div>
+      </div>
+    )
+  }
+  return null
+}
 
 export function PlatformBarChart({ data, title = 'Platform spend' }: PlatformBarChartProps) {
   const [mounted, setMounted] = React.useState(false)
@@ -57,7 +78,7 @@ export function PlatformBarChart({ data, title = 'Platform spend' }: PlatformBar
           axisLine={false}
           tickMargin={10}
         />
-        <ChartTooltip content={<ChartTooltipContent />} />
+        <ChartTooltip content={<CustomTooltip />} />
         <Bar 
           dataKey="expense" 
           name={title} 

--- a/features/analytics/components/SpendingTrendChart.tsx
+++ b/features/analytics/components/SpendingTrendChart.tsx
@@ -11,7 +11,8 @@ import {
 } from 'recharts'
 
 import { TrendPoint } from '@lib/analytics'
-import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent, ChartLegend, ChartLegendContent } from '@components/ui/chart'
+import { ChartConfig, ChartContainer, ChartTooltip, ChartLegend, ChartLegendContent } from '@components/ui/chart'
+import { formatPrice } from '@/lib/formatPrice'
 
 type SpendingTrendChartProps = {
   data: TrendPoint[]
@@ -27,6 +28,28 @@ const chartConfig = {
     color: "hsl(var(--chart-2))",
   },
 } satisfies ChartConfig
+
+const CustomTooltip = ({ active, payload, label }: any) => {
+  if (active && payload && payload.length) {
+    return (
+      <div className="rounded-lg border bg-background p-2 shadow-sm">
+        <div className="grid grid-cols-1 gap-2">
+          <div className="flex flex-col">
+            <span className="text-[0.70rem] uppercase text-muted-foreground">
+              {label}
+            </span>
+            {payload.map((entry: any, index: number) => (
+              <span key={index} className="font-bold" style={{ color: entry.color }}>
+                {entry.name === 'expense' ? 'Expenses' : 'Inflows'}: {formatPrice(entry.value)}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    )
+  }
+  return null
+}
 
 export function SpendingTrendChart({ data }: SpendingTrendChartProps) {
   const [mounted, setMounted] = React.useState(false)
@@ -70,7 +93,7 @@ export function SpendingTrendChart({ data }: SpendingTrendChartProps) {
           tickMargin={8}
           width={60}
         />
-        <ChartTooltip content={<ChartTooltipContent />} />
+        <ChartTooltip content={<CustomTooltip />} />
         <ChartLegend content={<ChartLegendContent />} />
         <Line 
           type="monotone" 

--- a/features/expenses/components/ExpensesList.tsx
+++ b/features/expenses/components/ExpensesList.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@components/ui/badge'
 import { Expense } from '@/types'
 import dayjs from 'dayjs'
 import { ArrowUpRight, ArrowDownRight } from 'lucide-react'
+import { formatPrice } from '@/lib/formatPrice'
 
 interface ExpensesListProps {
   expenses: Expense[]
@@ -72,7 +73,7 @@ export function ExpensesList({ expenses, isLoading }: ExpensesListProps) {
                 <div>
                   <div className="flex items-center space-x-2">
                     <span className="font-medium">
-                      {expense.currency} {expense.amount.toLocaleString()}
+                      {formatPrice(expense.amount)}
                     </span>
                     {expense.category && (
                       <span className="px-2 py-1 text-xs bg-secondary text-secondary-foreground rounded-full">
@@ -101,7 +102,7 @@ export function ExpensesList({ expenses, isLoading }: ExpensesListProps) {
                 <div className={`text-sm font-medium ${
                   expense.type === 'EXPENSE' ? 'text-red-600' : 'text-green-600'
                 }`}>
-                  {expense.type === 'EXPENSE' ? '-' : '+'}{expense.currency} {expense.amount.toLocaleString()}
+                  {expense.type === 'EXPENSE' ? '-' : '+'}{formatPrice(expense.amount)}
                 </div>
                 {expense.parsed_by_ai && (
                   <div className="text-xs text-muted-foreground">AI Parsed</div>

--- a/lib/formatPrice.ts
+++ b/lib/formatPrice.ts
@@ -1,0 +1,56 @@
+/**
+ * Formats a price amount in Indian Rupees (₹) with two display modes
+ *
+ * @param amount - The numeric amount to format
+ * @param shortHand - If true, uses shorthand notation (K/L), otherwise full format with Indian comma notation
+ * @returns Formatted price string with ₹ symbol
+ */
+export function formatPrice(amount: number | null | undefined, shortHand: boolean = false): string {
+  // Handle null/undefined values
+  if (amount == null || isNaN(amount)) {
+    return '₹ —';
+  }
+
+  // Always round up to nearest rupee
+  const roundedAmount = Math.ceil(amount);
+
+  if (shortHand) {
+    return formatShortHand(roundedAmount);
+  } else {
+    return formatFull(roundedAmount);
+  }
+}
+
+/**
+ * Formats amount in full Indian currency format with proper comma notation
+ */
+function formatFull(amount: number): string {
+  // Use Indian locale for proper comma placement (1,23,456 format)
+  const formatted = new Intl.NumberFormat('en-IN', {
+    maximumFractionDigits: 0,
+    minimumFractionDigits: 0,
+  }).format(amount);
+
+  return `₹ ${formatted}`;
+}
+
+/**
+ * Formats amount in shorthand notation using Indian conventions
+ * - < 1,000: ₹ 435 (no suffix)
+ * - >= 1,000 and < 1,00,000: ₹ 23.5k (thousands with 1 decimal)
+ * - >= 1,00,000: ₹ 2.18L (lakhs with 2 decimals)
+ */
+function formatShortHand(amount: number): string {
+  if (amount < 1000) {
+    // No suffix for amounts under 1000
+    return `₹ ${amount}`;
+  } else if (amount < 100000) {
+    // Thousands: divide by 1000, show 1 decimal place
+    const thousands = amount / 1000;
+    return `₹ ${thousands.toFixed(1)}k`;
+  } else {
+    // Lakhs: divide by 100000, show 2 decimal places for precision
+    const lakhs = amount / 100000;
+    return `₹ ${lakhs.toFixed(2)}L`;
+  }
+}


### PR DESCRIPTION
## Summary
Add Indian Rupee formatting with shorthand notation throughout the expense tracker application.

## Changes
- **New Utility**: Created `lib/formatPrice.ts` for consistent Indian currency formatting
- **Full Format**: Uses Indian comma notation (1,23,456 format) with ₹ symbol
- **Shorthand Notation**: 
  - Amounts < ₹1,000: Display as ₹435 (no suffix)
  - Amounts ≥ ₹1,000 and < ₹1,00,000: Display as ₹23.5k (thousands)
  - Amounts ≥ ₹1,00,000: Display as ₹2.18L (lakhs)
- **Error Handling**: Gracefully handles null/undefined values with "₹ —"
- **Updated Components**: Modified all data tables, charts, and preview cards to use the new formatting
- **Consistent Display**: Applied across expenses list, analytics dashboard, and preview components

## Files Changed
- `lib/formatPrice.ts` (new)
- `components/common/DataTable.tsx`
- `components/common/ExpensesPreviewCard.tsx`
- `components/common/BillsPreviewCard.tsx`
- `components/common/AnalyticsPreviewCard.tsx`
- `components/layout/Header.tsx`
- `features/analytics/components/AnalyticsDashboard.tsx`
- `features/analytics/components/CategoryPieChart.tsx`
- `features/analytics/components/CategoryTrendsChart.tsx`
- `features/analytics/components/PaymentMethodChart.tsx`
- `features/analytics/components/PlatformBarChart.tsx`
- `features/analytics/components/SpendingTrendChart.tsx`
- `features/expenses/components/ExpensesList.tsx`
- `app/settings/page.tsx`