### PR TITLE
Remove unused @expenses parallel route from app

### DIFF
--- a/app/@expenses/default.tsx
+++ b/app/@expenses/default.tsx
@@ -1,3 +1,0 @@
-export default function Default() {
-  return null
-}


### PR DESCRIPTION
## Summary
Root layout never rendered the expenses slot; delete the dead `app/@expenses/default.tsx` and folder.

## Changes
- Removed `app/@expenses/default.tsx` (Next.js parallel route that was never wired in layout)
- Removed empty `app/@expenses/` directory