### PR TITLE
fix(ui): minimalist sidebar and layout cleanup

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -72,7 +72,7 @@ function LoginContent() {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-muted/30 p-4">
-      <Card className="w-full max-w-sm">
+      <Card className="w-full max-w-sm shadow-lg">
         <CardHeader>
           <CardTitle>Sign in</CardTitle>
           <CardDescription>

--- a/components/layout/AppSidebar.tsx
+++ b/components/layout/AppSidebar.tsx
@@ -87,7 +87,6 @@ export function AppSidebar({ ...props }: AppSidebarProps) {
       <SidebarContent>
         <NavMain items={allNavItems} />
         <SidebarGroup>
-          <SidebarGroupLabel>Actions</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
               <SidebarMenuItem>

--- a/components/layout/SiteHeader.tsx
+++ b/components/layout/SiteHeader.tsx
@@ -20,7 +20,7 @@ import { ThemeTogglerButton } from '@/components/animations/components/buttons/t
 interface SiteHeaderProps {}
 
 const getPageTitle = (pathname: string): string => {
-  if (pathname === "/") return "Home"
+  if (pathname === "/" || pathname === "/dashboard") return "Dashboard"
   if (pathname === "/expenses") return "Expenses"
   if (pathname === "/analytics") return "Analytics"
   if (pathname === "/bills") return "Bills"

--- a/components/nav-main.tsx
+++ b/components/nav-main.tsx
@@ -90,7 +90,6 @@ export function NavMain({
 
   return (
     <SidebarGroup>
-      <SidebarGroupLabel>Navigation</SidebarGroupLabel>
       <SidebarMenu>
         {items.map((item) => {
           const hasSubItems = item.items && item.items.length > 0

--- a/features/bills/components/BillsTable.tsx
+++ b/features/bills/components/BillsTable.tsx
@@ -163,12 +163,12 @@ export default function BillsPage() {
         <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
             <div className="flex items-center justify-between">
               <div>
-                <h2 className="text-2xl font-semibold">Bills & Instances</h2>
+                <h2 className="text-xl font-semibold">Bills & Instances</h2>
                 <p className="text-sm text-muted-foreground">
                   Track due, paid, and skipped bill instances with filters.
                 </p>
               </div>
-              <div className="flex items-center gap-2">
+              <div className="flex flex-wrap items-center gap-2">
                 <Input
                   placeholder="Search by name or type"
                   value={search}


### PR DESCRIPTION
## Summary

- Remove redundant "Navigation" and "Actions" sidebar group labels
- Fix breadcrumb bug showing "Expense Tracker › Expense Tracker" on the dashboard route
- Reduce Bills page heading size (`text-2xl` → `text-xl`) and add `flex-wrap` to filter row
- Add `shadow-lg` to login card for a touch more depth

## Test plan

- [ ] Sidebar shows nav items without section labels
- [ ] Dashboard breadcrumb reads "Expense Tracker › Dashboard"
- [ ] Bills page header is visually lighter; filters wrap at narrow widths
- [ ] Login card has subtle shadow in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)