### PR TITLE
fix: add SVG favicon

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import Providers from './providers'
 export const metadata: Metadata = {
   title: 'Expense Tracker',
   description: 'AI-powered expense tracking app',
+  icons: { icon: '/favicon.svg', shortcut: '/favicon.svg' },
 }
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect x="3" y="9" width="26" height="18" rx="3" fill="#7c3aed"/>
+  <rect x="3" y="9" width="26" height="6" rx="2" fill="#6d28d9"/>
+  <rect x="18" y="14" width="9" height="8" rx="2" fill="#a78bfa"/>
+  <circle cx="22.5" cy="18" r="2.5" fill="#7c3aed"/>
+</svg>


### PR DESCRIPTION
## Summary
- Adds \`public/favicon.svg\` (wallet icon, purple to match app primary)
- Wires it up via Next.js layout metadata \`icons\` field
- Eliminates the 404 on \`/favicon.ico\` present on every page load

## Test plan
- [ ] Browser tab shows wallet icon
- [ ] No 404 for favicon in network panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)