### PR TITLE
fix: breadcrumb link, dead code cleanup, and console.debug correction

### DIFF
--- a/app/expenses/page.tsx
+++ b/app/expenses/page.tsx
@@ -6,8 +6,6 @@ import dayjs from 'dayjs'
 import { AppLayoutClient } from '@components/layout/AppLayoutClient'
 import { PreviewModal } from '@features/expenses/components/PreviewModal'
 import { DataTable } from '@components/common/DataTable'
-import { FloatingActionButton } from '@components/common/FloatingActionButton'
-import { useExpenseUIProvider } from '@/app/providers/index'
 import { useExpensesQuery, useCreateExpenseMutation } from '@/lib/query/hooks'
 import {
   BillMatchCandidate,
@@ -25,7 +23,6 @@ type ExpenseFilter = 'ALL' | 'EXPENSE' | 'INFLOW'
 import type { DateRange } from "react-day-picker"
 
 export default function ExpensesPage() {
-  // const { openExpenseDrawer } = useExpenseUIProvider()
   const { data: expenses = [], isLoading: isLoadingExpenses } = useExpensesQuery()
   const createExpenseMutation = useCreateExpenseMutation()
   const [previewDrawerOpen, setPreviewDrawerOpen] = useState(false)
@@ -186,7 +183,6 @@ export default function ExpensesPage() {
         billMatch={billMatch}
       />
 
-      {/* <FloatingActionButton onClick={openExpenseDrawer} /> */}
     </>
   )
 }

--- a/components/common/AnalyticsPreviewCard.tsx
+++ b/components/common/AnalyticsPreviewCard.tsx
@@ -27,7 +27,7 @@ export function AnalyticsPreviewCard() {
       const data = await analyticsApi.getAnalyticsData()
       setAnalyticsData(data)
     } catch (error) {
-      console.debug('Unexpected error fetching analytics data:', error)
+      console.error('Unexpected error fetching analytics data:', error)
     } finally {
       setIsLoading(false)
     }

--- a/components/layout/SiteHeader.tsx
+++ b/components/layout/SiteHeader.tsx
@@ -48,7 +48,7 @@ export function SiteHeader({}: SiteHeaderProps) {
         <Breadcrumb>
           <BreadcrumbList>
             <BreadcrumbItem className="hidden md:block">
-              <BreadcrumbLink href="#">
+              <BreadcrumbLink href="/">
                 Expense Tracker
               </BreadcrumbLink>
             </BreadcrumbItem>


### PR DESCRIPTION
## Summary
- Fix `BreadcrumbLink href='#'` → `href='/'` so clicking the root breadcrumb navigates home
- Remove stale commented-out `FloatingActionButton` and unused imports from `app/expenses/page.tsx`
- Fix `console.debug` → `console.error` in `AnalyticsPreviewCard` so analytics fetch errors are visible

## Test plan
- [ ] Clicking "Expense Tracker" in the breadcrumb navigates to home
- [ ] No unused imports or commented blocks in `app/expenses/page.tsx`
- [ ] Analytics fetch errors appear as `console.error` not silently swallowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)