### PR TITLE
fix: add page-specific metadata titles to all routes

### DIFF
--- a/app/analytics/layout.tsx
+++ b/app/analytics/layout.tsx
@@ -1,0 +1,7 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = { title: 'Analytics' }
+
+export default function AnalyticsLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,0 +1,7 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = { title: 'Dashboard' }
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/app/expenses/layout.tsx
+++ b/app/expenses/layout.tsx
@@ -1,0 +1,7 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = { title: 'Expenses' }
+
+export default function ExpensesLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/app/login/layout.tsx
+++ b/app/login/layout.tsx
@@ -1,0 +1,7 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = { title: 'Sign in' }
+
+export default function LoginLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/app/settings/layout.tsx
+++ b/app/settings/layout.tsx
@@ -1,0 +1,7 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = { title: 'Settings' }
+
+export default function SettingsLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}


### PR DESCRIPTION
## Summary
- Adds a thin `layout.tsx` per route to export `metadata.title` for pages that use `"use client"` (can't export metadata from client components directly)
- Routes covered: Dashboard, Expenses, Analytics, Settings, Sign in
- Browser tab and `<title>` tag now reflect the current route instead of always showing "Expense Tracker"

## Test plan
- [ ] Each tab title matches the current page (Dashboard, Expenses, Analytics, Settings, Sign in)
- [ ] Bills page still shows "Bills & Instances" (unchanged, already had metadata)
- [ ] No hydration or layout errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)