### PR TITLE
fix: add missing getServiceRoleClientIfAvailable to supabase mock (closes #33)

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -168,6 +168,7 @@ const mockSupabaseClient = {
 vi.mock('@server/db/supabase', () => ({
   supabase: mockSupabaseClient,
   getServiceRoleClient: () => mockSupabaseClient,
+  getServiceRoleClientIfAvailable: () => null,
   DB_UNAVAILABLE_MESSAGE: 'Database unavailable.',
 }))
 


### PR DESCRIPTION
## Summary

- The `@server/db/supabase` mock in `tests/setup.ts` was missing the `getServiceRoleClientIfAvailable` export
- This export was added to the production module but never added to the Vitest mock
- All 5 integration tests in `tests/integration/api/bill-instances.test.ts` were crashing at route startup with `No "getServiceRoleClientIfAvailable" export is defined on the "@server/db/supabase" mock`

## Root cause

`app/api/bill-instances/route.ts` imports `getServiceRoleClientIfAvailable` from `@server/db/supabase` at the top level (line 6) and calls it inside `getClient()` (line 15). Vitest's `vi.mock` factory for that module in `tests/setup.ts` only exported `supabase`, `getServiceRoleClient`, and `DB_UNAVAILABLE_MESSAGE` — the newer `getServiceRoleClientIfAvailable` function was never added, so Vitest threw an error the moment any test tried to call the route.

## Fix applied

Added `getServiceRoleClientIfAvailable: () => null` to the `vi.mock('@server/db/supabase', ...)` factory in `tests/setup.ts`. Returning `null` mirrors the real function's behaviour when `SUPABASE_SERVICE_ROLE_KEY` is not set (which is the case in the test environment), causing the route's `getClient()` to fall back to the mocked `supabase` client backed by the in-memory store.

## Tests

All 6 tests in `tests/integration/api/bill-instances.test.ts` are now expected to pass:
- `GET /api/bill-instances` > returns empty instances when none exist
- `GET /api/bill-instances` > filters by status when provided
- `POST /api/bill-instances` > creates instance for existing bill
- `POST /api/bill-instances` > returns error when bill not found
- `PATCH /api/bill-instances` > skip action marks instance as SKIPPED
- `PATCH /api/bill-instances` > update action updates amount

No new tests were needed — the existing suite is complete; it was only blocked by the missing mock export.

## Migration / env changes

None required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)