### PR TITLE
chore(analytics): remove 4 unused date-fns imports

### DIFF
--- a/server/services/analytics.service.ts
+++ b/server/services/analytics.service.ts
@@ -1,4 +1,3 @@
-import { format, startOfDay, startOfMonth, startOfWeek } from 'date-fns'
 import { Expense } from '@/types'
 import { expenseRepository } from '../db/repositories/expense.repo'
 import { fromUTC } from '../../lib/datetime'


### PR DESCRIPTION
## Summary
- Removed `format`, `startOfDay`, `startOfMonth`, and `startOfWeek` from the `date-fns` import in `server/services/analytics.service.ts`
- None of these functions appear anywhere in the service implementation

## Test plan
- [ ] `npm run test:run` passes with no regressions in analytics tests

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)