### PR TITLE
fix(expenses): add PATCH/DELETE handlers for /api/expenses/[id]

### DIFF
--- a/app/api/expenses/[id]/route.ts
+++ b/app/api/expenses/[id]/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest } from 'next/server'
+import { expenseService } from '@server/services/expense.service'
+import { updateExpenseSchema } from '@server/validators/expense.schema'
+import { requireAuth } from '@server/auth/context'
+import { successResponse, handleApiError } from '../../middleware'
+
+export const dynamic = 'force-dynamic'
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const user = await requireAuth(request)
+    const { id } = params
+    if (!id) {
+      throw Object.assign(new Error('Expense id is required'), { status: 400 })
+    }
+    const input = updateExpenseSchema.parse(await request.json())
+    const expense = await expenseService.updateExpense(id, input, user)
+    return successResponse({ expense })
+  } catch (error) {
+    return handleApiError(error)
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const user = await requireAuth(request)
+    const { id } = params
+    if (!id) {
+      throw Object.assign(new Error('Expense id is required'), { status: 400 })
+    }
+    await expenseService.deleteExpense(id, user)
+    return successResponse({ deleted: true })
+  } catch (error) {
+    return handleApiError(error)
+  }
+}

--- a/lib/api/expenses.ts
+++ b/lib/api/expenses.ts
@@ -58,7 +58,7 @@ export const expensesApi = {
 
   // Update an expense
   async updateExpense(id: string, updates: Partial<CreateExpenseRequest>): Promise<Expense> {
-    const response = await apiClient.put<{ expense: Expense }>(`/expenses/${id}`, updates)
+    const response = await apiClient.patch<{ expense: Expense }>(`/expenses/${id}`, updates)
     return response.data.expense
   },
 

--- a/server/services/expense.service.ts
+++ b/server/services/expense.service.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs'
 import { expenseRepository, ExpenseFilters, RepoAuthContext } from '../db/repositories/expense.repo'
 import { billRepository } from '../db/repositories/bill.repo'
-import { CreateExpenseInput } from '../validators/expense.schema'
+import { CreateExpenseInput, UpdateExpenseInput } from '../validators/expense.schema'
 import type { UserContext } from '../auth/context'
 import { Bill, BillMatchCandidate, Expense } from '@/types'
 import { toUTC, getLocalISO } from '@lib/datetime'
@@ -76,6 +76,16 @@ export class ExpenseService {
   async getExpenses(filters?: ExpenseFilters, user?: UserContext): Promise<Expense[]> {
     const auth = user ? toRepoAuth(user) : undefined
     return expenseRepository.getExpenses(filters, auth)
+  }
+
+  async updateExpense(id: string, updates: UpdateExpenseInput, user: UserContext): Promise<Expense> {
+    const auth = toRepoAuth(user)
+    return expenseRepository.updateExpense(id, updates, auth)
+  }
+
+  async deleteExpense(id: string, user: UserContext): Promise<void> {
+    const auth = toRepoAuth(user)
+    return expenseRepository.deleteExpense(id, auth)
   }
 
   private findBestBill(bills: Bill[], haystack: string, hint?: BillMatchCandidate | null): Bill | null {

--- a/server/validators/expense.schema.ts
+++ b/server/validators/expense.schema.ts
@@ -25,3 +25,15 @@ export const createExpenseSchema = z.object({
 })
 
 export type CreateExpenseInput = z.infer<typeof createExpenseSchema>
+
+export const updateExpenseSchema = z.object({
+  amount: z.number().positive().optional(),
+  datetime: z.string().optional(),
+  category: z.string().optional(),
+  platform: z.string().optional(),
+  payment_method: z.string().optional(),
+  type: z.enum(['EXPENSE', 'INFLOW']).optional(),
+  tags: z.array(z.string()).optional(),
+})
+
+export type UpdateExpenseInput = z.infer<typeof updateExpenseSchema>

--- a/tests/integration/api/expenses-id.test.ts
+++ b/tests/integration/api/expenses-id.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/expenses/route'
+import { PATCH, DELETE } from '@/app/api/expenses/[id]/route'
+import { clearMockStore, createExpensePayload } from '../../setup'
+
+beforeEach(() => {
+  clearMockStore()
+})
+
+function makeRequest(url: string, method: string, body?: object) {
+  return new NextRequest(url, {
+    method,
+    body: body ? JSON.stringify(body) : undefined,
+    headers: body ? { 'Content-Type': 'application/json' } : {},
+  })
+}
+
+function makeParams(id: string) {
+  return { params: { id } }
+}
+
+async function createExpense() {
+  const req = makeRequest('http://localhost/api/expenses', 'POST', createExpensePayload)
+  const res = await POST(req)
+  const body = await res.json()
+  return body.data.expense
+}
+
+describe('PATCH /api/expenses/[id]', () => {
+  it('updates an existing expense and returns the updated record', async () => {
+    const expense = await createExpense()
+
+    const res = await PATCH(
+      makeRequest(`http://localhost/api/expenses/${expense.id}`, 'PATCH', {
+        amount: 999,
+        category: 'Updated',
+      }),
+      makeParams(expense.id)
+    )
+
+    const body = await res.json()
+    expect(res.status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.data.expense).toBeDefined()
+    expect(body.data.expense.id).toBe(expense.id)
+    expect(body.data.expense.amount).toBe(999)
+    expect(body.data.expense.category).toBe('Updated')
+  })
+
+  it('updates only the provided fields (partial update)', async () => {
+    const expense = await createExpense()
+
+    const res = await PATCH(
+      makeRequest(`http://localhost/api/expenses/${expense.id}`, 'PATCH', {
+        platform: 'Swiggy',
+      }),
+      makeParams(expense.id)
+    )
+
+    const body = await res.json()
+    expect(res.status).toBe(200)
+    expect(body.data.expense.platform).toBe('Swiggy')
+    // Original fields remain unchanged
+    expect(body.data.expense.amount).toBe(expense.amount)
+  })
+
+  it('returns 400 for invalid payload (negative amount)', async () => {
+    const expense = await createExpense()
+
+    const res = await PATCH(
+      makeRequest(`http://localhost/api/expenses/${expense.id}`, 'PATCH', {
+        amount: -50,
+      }),
+      makeParams(expense.id)
+    )
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.error?.code).toBe('VALIDATION_ERROR')
+  })
+})
+
+describe('DELETE /api/expenses/[id]', () => {
+  it('deletes an existing expense and returns deleted: true', async () => {
+    const expense = await createExpense()
+
+    const res = await DELETE(
+      makeRequest(`http://localhost/api/expenses/${expense.id}`, 'DELETE'),
+      makeParams(expense.id)
+    )
+
+    const body = await res.json()
+    expect(res.status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.data.deleted).toBe(true)
+  })
+
+  it('confirms the expense is no longer accessible after deletion', async () => {
+    const { GET } = await import('@/app/api/expenses/route')
+    const expense = await createExpense()
+
+    await DELETE(
+      makeRequest(`http://localhost/api/expenses/${expense.id}`, 'DELETE'),
+      makeParams(expense.id)
+    )
+
+    // Verify the expense list is now empty
+    const listRes = await GET(new NextRequest('http://localhost/api/expenses'))
+    const listBody = await listRes.json()
+    expect(listBody.data.expenses.length).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- `app/api/expenses/[id]/route.ts` did not exist — all edit and delete actions from the UI failed silently with 404/405
- Created `PATCH` and `DELETE` route handlers following project conventions (`requireAuth`, Zod validation, `successResponse`/`handleApiError`)
- Added `updateExpenseSchema` (all fields optional for partial updates) to `expense.schema.ts`
- Added `updateExpense` and `deleteExpense` methods to `ExpenseService`
- Updated `lib/api/expenses.ts` to use `.patch()` instead of `.put()` to match the new handler

## Test plan
- [ ] `PATCH /api/expenses/:id` updates and returns the modified expense
- [ ] `DELETE /api/expenses/:id` removes the expense
- [ ] Invalid PATCH payload returns 400 validation error
- [ ] Integration tests in `tests/integration/api/expenses-id.test.ts` pass

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)