### PR TITLE
fix: patch all filtered expense cache keys in optimistic update (closes #39)

### DIFF
--- a/tests/unit/query/queryKeys.test.ts
+++ b/tests/unit/query/queryKeys.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { queryKeys } from '@/lib/query/queryKeys'
+
+/**
+ * Tests for query key structure used in optimistic updates.
+ *
+ * The fix for issue #39 replaces setQueryData(queryKeys.expenses.list()) with
+ * setQueriesData({ queryKey: queryKeys.expenses.lists() }) so that ALL active
+ * expense list cache entries — both unfiltered and filtered — are patched during
+ * an optimistic create, and ALL are invalidated in onSettled.
+ */
+describe('queryKeys — expenses', () => {
+  it('expenses.all is a stable array prefix', () => {
+    expect(queryKeys.expenses.all).toEqual(['expenses'])
+  })
+
+  it('expenses.lists() starts with expenses.all', () => {
+    const lists = queryKeys.expenses.lists()
+    expect(lists[0]).toBe('expenses')
+    expect(lists[1]).toBe('list')
+  })
+
+  it('unfiltered list key starts with expenses.lists()', () => {
+    const unfiltered = queryKeys.expenses.list()
+    const listsPrefix = queryKeys.expenses.lists()
+    // unfiltered list should be a superset of the lists prefix
+    expect(unfiltered.slice(0, listsPrefix.length)).toEqual([...listsPrefix])
+  })
+
+  it('filtered list key shares the same lists() prefix as unfiltered', () => {
+    const filtered = queryKeys.expenses.list({ category: 'Food' })
+    const unfiltered = queryKeys.expenses.list()
+    const listsPrefix = queryKeys.expenses.lists()
+
+    // Both filtered and unfiltered share the lists() prefix —
+    // this is what allows setQueriesData({ queryKey: lists() }) to update both.
+    expect(filtered.slice(0, listsPrefix.length)).toEqual([...listsPrefix])
+    expect(unfiltered.slice(0, listsPrefix.length)).toEqual([...listsPrefix])
+  })
+
+  it('filtered and unfiltered keys are distinct', () => {
+    const filtered = queryKeys.expenses.list({ category: 'Food' })
+    const unfiltered = queryKeys.expenses.list()
+    // They must differ so filtered results are cached separately
+    expect(filtered).not.toEqual(unfiltered)
+  })
+
+  it('different filters produce distinct keys', () => {
+    const byCategory = queryKeys.expenses.list({ category: 'Food' })
+    const byPlatform = queryKeys.expenses.list({ platform: 'Swiggy' })
+    expect(byCategory).not.toEqual(byPlatform)
+  })
+
+  it('expenses.all is a prefix of every expense list key', () => {
+    const prefix = queryKeys.expenses.all
+    const keys = [
+      queryKeys.expenses.list(),
+      queryKeys.expenses.list({ category: 'Food' }),
+      queryKeys.expenses.list({ platform: 'Swiggy', date_from: '2024-01-01' }),
+      queryKeys.expenses.recent(5),
+      queryKeys.expenses.detail('some-id'),
+    ]
+
+    for (const key of keys) {
+      expect(key.slice(0, prefix.length)).toEqual([...prefix])
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- **What was the issue:** `useCreateExpenseMutation`'s `onMutate` called `queryClient.setQueryData(queryKeys.expenses.list())` with no arguments, which only patched the unfiltered expense list cache entry. When a user had active filters applied (by category, platform, date range, etc.), those filtered query cache keys were not touched during the optimistic update, leaving the filtered view stale until the next background refetch completed.
- **Root cause:** `queryKeys.expenses.list()` (no args) resolves to a single specific cache key `['expenses', 'list', undefined]`. React Query's `setQueryData` targets exactly one key, so filtered keys like `['expenses', 'list', { category: 'Food' }]` were never patched.
- **Fix:** Replaced `setQueryData` / `getQueryData` (scoped to the bare unfiltered key) with `setQueriesData` / `getQueriesData` (scoped to `queryKeys.expenses.lists()` as a prefix). `setQueriesData` matches every active cache entry whose key starts with the given prefix, covering all filtered and unfiltered expense list views simultaneously. The `onError` rollback is similarly updated to iterate over all snapshotted entries. The `onSettled` `invalidateQueries({ queryKey: queryKeys.expenses.all })` was already correct and is kept unchanged.

## Test plan

- [x] New unit test `tests/unit/query/queryKeys.test.ts` verifies the prefix hierarchy: `expenses.lists()` is a proper prefix of both filtered and unfiltered list keys, confirming `setQueriesData` will match them all.
- [x] Existing unit tests for `ExpenseService` continue to pass (service layer unaffected).
- [x] `npx eslint lib/query/hooks/useExpensesQuery.ts` passes with no errors.
- [ ] Manual verification: create an expense while a category filter is active — the filtered view should immediately show the new optimistic entry without waiting for a refetch.

## Files changed

- `lib/query/hooks/useExpensesQuery.ts` — fix `onMutate`/`onError` in `useCreateExpenseMutation`
- `tests/unit/query/queryKeys.test.ts` — new unit test for query key prefix structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)