### PR TITLE
fix(types): make UserContext.roles readonly — fix TS2345 across service tests

### DIFF
--- a/server/auth/context.ts
+++ b/server/auth/context.ts
@@ -8,7 +8,7 @@ export interface UserContext {
   email: string | null
   isMaster: boolean
   isDemo: boolean
-  roles: string[]
+  roles: readonly string[]
 }
 
 const DEMO_EMAIL = 'demo@expense-tracker.app'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
+    "types": ["vitest/globals"],
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary
- Changed `roles: string[]` to `roles: readonly string[]` in `UserContext` interface (`server/auth/context.ts`) — fixes TS2345 in all 3 service test files (21 total errors) where `as const` fixture objects infer `readonly ["user"]`
- Added `"types": ["vitest/globals"]` to `tsconfig.json` so TypeScript recognises `describe`, `it`, `expect`, `vi` globals in UI test files

## Test plan
- [ ] `npx vitest run tests/unit/services/` passes with no TS2345 errors
- [ ] `tsc --noEmit` reports no "Cannot find name" errors for Vitest globals

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)