### PR TITLE
fix(expenses): add bill_instance_id to CreateExpenseData interface and test fixtures

### DIFF
--- a/server/db/repositories/expense.repo.ts
+++ b/server/db/repositories/expense.repo.ts
@@ -19,6 +19,7 @@ export interface CreateExpenseData {
   raw_text: string | null
   source: ExpenseSource
   bill_id: string | null
+  bill_instance_id?: string | null
 }
 
 export interface ExpenseFilters {

--- a/tests/integration/ui/analytics/export-utils.test.tsx
+++ b/tests/integration/ui/analytics/export-utils.test.tsx
@@ -57,6 +57,7 @@ describe('Export Utilities', () => {
         raw_text: null,
         source: 'MANUAL',
         bill_id: null,
+        bill_instance_id: null,
         created_at: '2026-02-08T10:00:00Z',
       },
       {
@@ -73,6 +74,7 @@ describe('Export Utilities', () => {
         raw_text: 'uber ride to office',
         source: 'AI',
         bill_id: null,
+        bill_instance_id: null,
         created_at: '2026-02-07T15:30:00Z',
       },
     ]

--- a/tests/integration/ui/analytics/filters-panel.test.tsx
+++ b/tests/integration/ui/analytics/filters-panel.test.tsx
@@ -19,6 +19,7 @@ const mockExpenses: Expense[] = [
     raw_text: null,
     source: 'MANUAL',
     bill_id: null,
+    bill_instance_id: null,
     created_at: '2026-02-08T10:00:00Z',
   },
   {
@@ -35,6 +36,7 @@ const mockExpenses: Expense[] = [
     raw_text: 'uber ride',
     source: 'AI',
     bill_id: null,
+    bill_instance_id: null,
     created_at: '2026-02-07T15:30:00Z',
   },
 ]


### PR DESCRIPTION
## Summary
- Added `bill_instance_id?: string | null` to `CreateExpenseData` interface in `expense.repo.ts` — the column exists in the database but was missing from the TypeScript insert interface, so it was never populated
- Added `bill_instance_id: null` to `Expense` fixture objects in `export-utils.test.tsx` and `filters-panel.test.tsx` to resolve TS2741 type errors

## Root cause
The `bill_instance_id` column exists in the `expenses` table (added in `sql/init.sql` with an index) but `CreateExpenseData` was never updated to include it. The filter at `expense.repo.ts:95` queries by `bill_instance_id` correctly — the underlying column is present.

## Test plan
- [ ] Creating an expense with `bill_instance_id` set correctly persists the value
- [ ] `GET /api/expenses?bill_instance_id=<id>` returns only the matched expenses
- [ ] No TS2741 errors on Expense fixtures in analytics tests

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)