### PR TITLE
fix: replace hardcoded red/green colors with semantic tokens for dark mode (closes #56)

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -292,7 +292,7 @@ function BillForm({
             <Label htmlFor="auto_post">Auto post to expenses</Label>
           </div>
         </div>
-        {error && <p className="text-sm text-red-500">{error}</p>}
+        {error && <p className="text-sm text-destructive">{error}</p>}
         <div className="flex justify-end">
           <Button onClick={handleSubmit} disabled={createBillMutation.isPending}>
             {createBillMutation.isPending ? 'Saving...' : 'Save'}

--- a/components/common/SectionCards.tsx
+++ b/components/common/SectionCards.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import { ArrowUpRight, ArrowDownRight, TrendingUp } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { StaggerContainer, StaggerItem, AnimatedNumber, AnimatedIcon, AnimatedCard } from "@/components/animations"
+import { cn } from "@/lib/utils"
 
 interface SectionCardsProps {
   expenseTotal: number
@@ -27,7 +28,7 @@ export function SectionCards({ expenseTotal, inflowTotal, net, currency }: Secti
             />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-red-600">
+            <div className="text-2xl font-bold text-destructive">
               {currency}{" "}
               <AnimatedNumber
                 value={expenseTotal}
@@ -53,7 +54,7 @@ export function SectionCards({ expenseTotal, inflowTotal, net, currency }: Secti
             />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-green-600">
+            <div className="text-2xl font-bold text-emerald-600 dark:text-emerald-400">
               {currency}{" "}
               <AnimatedNumber
                 value={inflowTotal}
@@ -79,7 +80,7 @@ export function SectionCards({ expenseTotal, inflowTotal, net, currency }: Secti
             />
           </CardHeader>
           <CardContent>
-            <div className={`text-2xl font-bold ${net >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+            <div className={cn('text-2xl font-bold', net >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-destructive')}>
               {net >= 0 ? '+' : ''}{currency}{" "}
               <AnimatedNumber
                 value={Math.abs(net)}


### PR DESCRIPTION
## Summary

- Replaces all hardcoded `text-red-600`, `text-red-500`, `text-green-600`, `bg-red-100`, and `bg-green-100` classes with semantic design tokens that adapt correctly in dark mode
- Converts all template literal class conditionals to use `cn()` for consistency with project conventions
- Adds missing `cn` import to files that needed it

## Root cause

Hardcoded Tailwind color classes (`red-600`, `green-600`, etc.) do not adapt to dark mode. The project uses CSS variables for theming, so semantic tokens like `text-destructive` and `text-emerald-600 dark:text-emerald-400` must be used instead.

## Replacements applied

| Old | New |
|-----|-----|
| `text-red-600` / `text-red-500` | `text-destructive` |
| `text-green-600` | `text-emerald-600 dark:text-emerald-400` |
| `bg-red-100 text-red-600` | `bg-destructive/10 text-destructive` |
| `bg-green-100 text-green-600` | `bg-emerald-500/10 text-emerald-600 dark:text-emerald-400` |
| Template literal class conditionals | `cn()` calls |

## Files changed

- `features/expenses/components/ExpensesList.tsx` — type icon badges and amount display
- `components/common/SectionCards.tsx` — KPI card values
- `components/common/DataTable.tsx` — arrow icons in amount column
- `components/common/AnalyticsPreviewCard.tsx` — net/expense/income values
- `features/analytics/components/AnalyticsDashboard.tsx` — `SummaryStat` component
- `features/analytics/components/BillReconciliation.tsx` — adjustment values
- `app/settings/page.tsx` — error message in `BillForm`
- `features/bills/components/BillsTable.tsx` — error message in manual instance drawer

## Test plan

- [ ] Verify expense list shows correct destructive/emerald colors in light mode
- [ ] Verify expense list shows correct destructive/emerald colors in dark mode
- [ ] Verify KPI cards in dashboard show correct colors in both modes
- [ ] Verify analytics preview card shows correct colors in both modes
- [ ] Verify bill reconciliation adjustment colors in both modes
- [ ] Verify error messages in settings and bills pages use destructive color

## Notes

The `react-hooks/preserve-manual-memoization` lint error in `BillReconciliation.tsx` at line 82 is pre-existing and unrelated to this change (confirmed by checking the error exists on the base branch before any of these changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)